### PR TITLE
Use string interpolation por concatting

### DIFF
--- a/lib/fdoc/presenters/endpoint_presenter.rb
+++ b/lib/fdoc/presenters/endpoint_presenter.rb
@@ -180,7 +180,7 @@ class Fdoc::EndpointPresenter < Fdoc::BasePresenter
     example = ''
     if object["properties"]
       object["properties"].each do |key, value|
-        example += key+"="+example_from_schema(value) + "&"
+        example += "#{key}=#{example_from_schema(value)}&"
       end
     end
     example.sub(/\&$/,'')


### PR DESCRIPTION
Fixes the following:

vagrant@precise64 /web/services/rosi_catalog_service (master*) $ rake fdoc:to_html
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/fdoc-830e0b954c5a/lib/fdoc/presenters/endpoint_presenter.rb:183:in `+': no implicit conversion of Fixnum into String (TypeError)
