### PR TITLE
Merge in upstream master for rspec 3 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ end
 To enable fdoc for an endpoint, add the `fdoc` option with the path to the endpoint. fdoc will intercept all calls to `get`, `post`, `put`, and `delete` and verify those parameters accordingly.
 
 ```ruby
-context "#show", :fdoc => 'members/list' do
+context "#show", fdoc: 'members/list' do
   # ...
 end
 ```
@@ -152,7 +152,7 @@ Our spec file, `spec/controllers/members_controller_spec.rb` looks like:
 require 'fdoc/spec_watcher'
 
 describe MembersController do
-  context "#show", :fdoc => "members/list" do
+  context "#show", fdoc: "members/list" do
     it "can take an offset" do
       get :show, {
         :offset => 5

--- a/docs/scaffold.md
+++ b/docs/scaffold.md
@@ -8,11 +8,13 @@ require 'fdoc/spec_watcher'
 describe MembersController do
   include Fdoc::SpecWatcher
 
-  context "#list", :fdoc => 'members/list' do
-    get :list, {
-      :limit => 10,
-      :older_than => Time.gm(2012,"jun",21,10,40,00)
-    }
+  context "#list", fdoc: 'members/list' do
+    it "lists members scoped to age" do
+      get :list, {
+        limit: 10,
+        older_than: Time.gm(2012,"jun",21,10,40,00)
+      }
+    end
   end
 end
 ````

--- a/lib/fdoc/endpoint_scaffold.rb
+++ b/lib/fdoc/endpoint_scaffold.rb
@@ -17,7 +17,7 @@ class Fdoc::EndpointScaffold < Fdoc::Endpoint
 
   def persist!
     dirname = File.dirname(@endpoint_path)
-    Dir.mkdir(dirname) unless File.directory?(dirname)
+    FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
 
     File.open(@endpoint_path, "w") do |file|
       YAML.dump(@schema, file)

--- a/lib/fdoc/spec_watcher.rb
+++ b/lib/fdoc/spec_watcher.rb
@@ -35,7 +35,9 @@ module Fdoc
     end
 
     def path
-      if respond_to?(:example) # Rspec 2
+      if RSpec.respond_to?(:current_example) # Rspec 3
+        RSpec.current_example.metadata[:fdoc]
+      elsif respond_to?(:example) # Rspec 2
         example.metadata[:fdoc]
       else # Rspec 1.3.2
         opts = {}


### PR DESCRIPTION
This merges in upstream changes to allow for the SpecWatcher module
to be used with rspec 3.

Also, pinned the version of rspec for development to ~> 2.14.1.
Using ~> 2.5 allowed for an update to 2.99, which causes breaking
specs.
